### PR TITLE
Hot fix for multiple subs/pubs in ROS

### DIFF
--- a/igvc_ws/src/ros_api/__init__.py
+++ b/igvc_ws/src/ros_api/__init__.py
@@ -2,7 +2,7 @@
 
 '''
 This is a package to abstract communicating with the ros program through python.
-Last edited: 25 Jan 2019
+Last edited: 31 Jan 2019
 Author: Isaac
 '''
 

--- a/igvc_ws/src/ros_api/__init__.py
+++ b/igvc_ws/src/ros_api/__init__.py
@@ -12,3 +12,8 @@ from main import ROS_Subscriber
 
 from util import *
 
+from rospy import is_shutdown 
+from rospy import init_node
+from rospy import sleep
+from rospy import spin
+

--- a/igvc_ws/src/ros_api/main.py
+++ b/igvc_ws/src/ros_api/main.py
@@ -6,6 +6,7 @@ Last Updated: 26 Jan 2019
 Author: Isaac
 '''
 
+import util
 from util import println
 
 import rospy
@@ -18,24 +19,18 @@ class ROS_Handler(object):
         It typically should not be created, rather is a base class for inheritance.
     '''
 
-    def __init__(self, svr_name, topic, msg_type, rate, anonymous=False):
+    def __init__(self, topic, msg_type, rate):
         ''' This is the ROS_Handler constructor
 
-            Args:   svr_name - the name of the node to initialize
-                    topic - the topic name (this must be the same for the subscriber and publisher for communication)
+            Args:   topic - the topic name (this must be the same for the subscriber and publisher for communication)
                     msg_type - the ROS message being passed
                     rate - number of times per second the node is run by ROS
-
-            Kwargs: anonymous - initializes the node as anonymous (for subscribers)
 
             Returns:    A ROS_Handler object
         '''
 
-        self.svr_name = svr_name
         self.topic = topic
         self.msg_type = msg_type
-
-        rospy.init_node(self.svr_name, anonymous=anonymous)
         self.rate = rospy.Rate(rate)
 
     def set_rate(self, r):
@@ -52,7 +47,7 @@ class ROS_Publisher(ROS_Handler):
         A basic wrapper for a ROS publisher.
     '''
 
-    def __init__(self, svr_name, topic, msg_type, q_size=10, rate=10):
+    def __init__(self, topic, msg_type, q_size=10, rate=10):
         ''' This is the ROS_Publisher constructor
 
             Args:   see ROS_Handler constructor
@@ -61,7 +56,7 @@ class ROS_Publisher(ROS_Handler):
             Returns: A ROS_Publisher object
         '''
 
-        super(ROS_Publisher,self).__init__(svr_name, topic, msg_type, rate)
+        super(ROS_Publisher,self).__init__(topic, msg_type, rate)
         self.pub = rospy.Publisher(self.topic, self.msg_type, queue_size=q_size)
 
     def send(self, *args, **kwargs):
@@ -81,7 +76,7 @@ class ROS_Subscriber(ROS_Handler):
         A basic wrapper for a ROS subscriber.
     '''
 
-    def __init__(self, svr_name, topic, msg_type, call=None, rate=10):
+    def __init__(self, topic, msg_type, call=None, rate=10):
         ''' This is the ROS_Subscriber constructor
 
             Args:   see ROS_Handler constructor
@@ -90,7 +85,7 @@ class ROS_Subscriber(ROS_Handler):
             Returns: A ROS_Subscriber object
         '''
 
-        super(ROS_Subscriber,self).__init__(svr_name, topic, msg_type, rate, anonymous=True)
+        super(ROS_Subscriber,self).__init__(topic, msg_type, rate)
         self.callback = self.default_callback if call == None else call
         self.sub = rospy.Subscriber(self.topic, self.msg_type, self.callback)
 
@@ -102,7 +97,7 @@ class ROS_Subscriber(ROS_Handler):
             Returns: None
         '''
 
-        println('Recieved: {}'.format(data))
+        println('Recieved: {}'.format(util.msg_to_dict(data)))
 
     def new_callback(self, call):
         ''' Re-creates the subscriber with a different callback function

--- a/igvc_ws/src/ros_api/main.py
+++ b/igvc_ws/src/ros_api/main.py
@@ -2,7 +2,7 @@
 
 '''
 This is the core ros module that wraps key ROS functions that external users will use to call ROS functions
-Last Updated: 26 Jan 2019
+Last Updated: 31 Jan 2019
 Author: Isaac
 '''
 

--- a/igvc_ws/src/ros_api/util.py
+++ b/igvc_ws/src/ros_api/util.py
@@ -28,17 +28,7 @@ def println (*args, **kwargs):
     sys.stdout.write(''.join(map(str, args)).strip() + kwargs['end'])
     sys.stdout.flush()
 
-def ros_spin():
-    ''' This is a function to make the python script not exit (for subscribers) 
-        
-        Args:   None
-
-        Returns:    None
-    '''
-
-    rospy.spin()
-
-def ros_is_running():
+def is_running():
     ''' Tells if the ros node is running
 
         Args:   None
@@ -47,27 +37,6 @@ def ros_is_running():
     '''
 
     return not rospy.is_shutdown()
-
-def ros_is_shutdown():
-    ''' Tells if the ros node is not running
-
-        Args:   None
-
-        Returns:    True if the node is not running, False if it is
-    '''
-
-    return rospy.is_shutdown()
-
-def ros_sleep(time):
-    ''' Makes the ros_node sleep a given time
-
-        Args:   time - time to sleep in seconds
-
-        Returns:    None
-    '''
-
-    rospy.sleep(time)
-
 
 def json_to_msg(j_str, msg_type):
     ''' Converts a JSON string to a message object

--- a/igvc_ws/src/ros_api/util.py
+++ b/igvc_ws/src/ros_api/util.py
@@ -2,7 +2,7 @@
 
 '''
 This is a script for basic useful utilities and functions.
-Last edited: 26 Jan 2019
+Last edited: 31 Jan 2019
 Author: Isaac
 '''
 

--- a/igvc_ws/src/test_pkg/src/test.py
+++ b/igvc_ws/src/test_pkg/src/test.py
@@ -8,7 +8,6 @@ Author: Isaac
 
 import std_msgs.msg as std_msgs
 import custom_msgs.msg as msgs
-# import msg as msgs
 
 import ros_api as ros
 from ros_api import println, is_running, sleep

--- a/igvc_ws/src/test_pkg/src/test.py
+++ b/igvc_ws/src/test_pkg/src/test.py
@@ -2,7 +2,7 @@
 
 '''
 A test script to act as a publisher from the ros_api.
-Last Updated: 26 Jan 2019
+Last Updated: 31 Jan 2019
 Author: Isaac
 '''
 
@@ -11,19 +11,25 @@ import custom_msgs.msg as msgs
 # import msg as msgs
 
 import ros_api as ros
-from ros_api import println, ros_is_running, ros_sleep
+from ros_api import println, is_running, sleep
 
 if __name__ == '__main__':
     println('Starting test pkg')
     
-    handler = ros.ROS_Publisher('test_publisher', 'test_topic', msgs.coord)
-    while ros_is_running():
-        # handler.send(32,10,500)
-        # handler.send(x=10,y=32,z=40)
+    ros.init_node('pub_node')
+    pub1 = ros.ROS_Publisher('test_topic', msgs.coord)
+    pub2 = ros.ROS_Publisher('another_topic', msgs.coord)
+
+    while is_running():
+        # pub1.send(32,10,500)
+        # pub1.send(x=10,y=32,z=40)
 
         m = ros.json_to_msg('{"x":5,"y":2,"z":14}', msgs.coord)
-        handler.send(m)
-        ros_sleep(1)
+        pub1.send(m)
+
+        pub2.send(32,102,1)
+
+        sleep(1)
 
 
     println('Node finished with no errors')

--- a/igvc_ws/src/test_recieve/src/r_test.py
+++ b/igvc_ws/src/test_recieve/src/r_test.py
@@ -2,7 +2,7 @@
 
 '''
 A test script to recieve data using ros_api
-Last Updated: 26 Jan 2019
+Last Updated: 31 Jan 2019
 Author: Isaac
 '''
 
@@ -11,7 +11,7 @@ import std_msgs.msg as std_msgs
 import custom_msgs.msg as msgs
 
 import ros_api as ros
-from ros_api import println, ros_spin
+from ros_api import println, spin
 
 def custom_callback(data):
     #println('Recieved custom: {}'.format(data))
@@ -20,8 +20,10 @@ def custom_callback(data):
 if __name__ == '__main__':
     println('Starting test revieve')
 
-    handler = ros.ROS_Subscriber('test_subscriber', 'test_topic', msgs.coord, call=custom_callback)
-    ros_spin()
+    ros.init_node('test')
+    sub1 = ros.ROS_Subscriber( 'test_topic', msgs.coord, call=custom_callback)
+    sub2 = ros.ROS_Subscriber('another_topic', msgs.coord)
+    spin()
 
     println('Node finished with no errors')
 


### PR DESCRIPTION
This changes the names of several of the ROS_API functions, some code in other packages may need to be updated.

This change pretty much makes the publisher wrappers pretty useless, but I think we should continue to use them since they will allow us more customization in the future that we just don't use right now.